### PR TITLE
feat(*): Updated all references of robsontenorio to mindedge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <img src="bird.png">  
+  <img src="bird.png">
 </p>
 <p align="center">
-  <a href="https://codecov.io/gh/robsontenorio/vue-api-query">
-    <img src="https://codecov.io/gh/robsontenorio/vue-api-query/branch/master/graph/badge.svg" />
+  <a href="https://codecov.io/gh/mindedge/vue-api-query">
+    <img src="https://codecov.io/gh/mindedge/vue-api-query/branch/master/graph/badge.svg" />
   </a>
-  <a href="https://actions-badge.atrox.dev/robsontenorio/vue-api-query/goto?ref=dev">
-    <img src="https://img.shields.io/github/workflow/status/robsontenorio/vue-api-query/Test%20and%20Release?style=flat&label=actions&logo=github" />
+  <a href="https://actions-badge.atrox.dev/mindedge/vue-api-query/goto?ref=dev">
+    <img src="https://img.shields.io/github/workflow/status/mindedge/vue-api-query/Test%20and%20Release?style=flat&label=actions&logo=github" />
   </a>
   <a href="https://www.npmjs.com/package/vue-api-query">
     <img src="https://img.shields.io/npm/dt/vue-api-query.svg" />
@@ -14,42 +14,41 @@
   <a href="https://www.npmjs.com/package/vue-api-query">
     <img src="https://img.shields.io/npm/v/vue-api-query.svg" />
   </a>
-  <a href="https://github.com/robsontenorio/vue-api-query/blob/master/LICENSE">
+  <a href="https://github.com/mindedge/vue-api-query/blob/master/LICENSE">
     <img src="https://img.shields.io/apm/l/vim-mode.svg" />
-  </a>     
+  </a>
 </p>
 
 # Elegant and simple way to build requests for REST API
 
-This package helps you quickly to build requests for REST API. Move your logic and backend requests to dedicated classes. 
-Keep your code clean and elegant. 
+This package helps you quickly to build requests for REST API. Move your logic and backend requests to dedicated classes.
+Keep your code clean and elegant.
 
-🔥 If you use Laravel, this package matches perfectly with 
+🔥 If you use Laravel, this package matches perfectly with
 [spatie/laravel-query-builder](https://github.com/spatie/laravel-query-builder).
 
 ## Links
-- [✨ &nbsp;Release Notes](https://robsontenorio.github.io/vue-api-query/releases)
-- [📖 &nbsp;Documentation](https://robsontenorio.github.io/vue-api-query)
+
+- [✨ &nbsp;Release Notes](https://mindedge.github.io/vue-api-query/releases)
+- [📖 &nbsp;Documentation](https://mindedge.github.io/vue-api-query)
 
 ## Contributors
 
 Thanks to the following people who have contributed to this project:
 
-* [@JoaoPedroAS51](https://github.com/JoaoPedroAS51)
-* [@Peter-Krebs](https://github.com/Peter-Krebs)
+- [@JoaoPedroAS51](https://github.com/JoaoPedroAS51)
+- [@Peter-Krebs](https://github.com/Peter-Krebs)
 
-[See all contributors](https://github.com/robsontenorio/vue-api-query/graphs/contributors)
+[See all contributors](https://github.com/mindedge/vue-api-query/graphs/contributors)
 
 ## Thanks
 
-* Inspiration from [milroyfraser/sarala](https://github.com/milroyfraser/sarala).
+- Inspiration from [milroyfraser/sarala](https://github.com/milroyfraser/sarala).
 
-* Elegancy from [DavidDuwaer/coloquent](https://github.com/DavidDuwaer/Coloquent). 
-
+- Elegancy from [DavidDuwaer/coloquent](https://github.com/DavidDuwaer/Coloquent).
 
 Why another package if we have those? Because currently (march, 2018) they restricted backend response to JSON API specification.
 
 ## Contact
 
-Twitter [@robsontenorio](https://twitter.com/robsontenorio)
-
+Twitter [@mindedge](https://twitter.com/mindedge)

--- a/docs/content/en/building-the-query.md
+++ b/docs/content/en/building-the-query.md
@@ -7,13 +7,13 @@ category: Getting Started
 
 See the [API reference](/api/query-builder-methods) for a list of available query builder methods.
 
-With our models already set up, it's time to start using them! 
+With our models already set up, it's time to start using them!
 
 ## Retrieving a List of Records
 
 See the [API reference](/api/query-builder-methods#get)
 
-Let's start initializing a model and building a simple query that gets all records from the database. 
+Let's start initializing a model and building a simple query that gets all records from the database.
 To achieve this, we can use the `get` method or its alias `all`.
 
 We can get a list of posts using the **Post** model:
@@ -21,95 +21,95 @@ We can get a list of posts using the **Post** model:
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = new Post().get()
-  ```
+```js
+const posts = new Post().get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts
-  ```
+```http request
+GET /posts
+```
 
   </code-block>
   <code-block label="Response">
 
-  ```js
-  [
-    /* ... */
-    {
+```js
+;[
+  /* ... */
+  {
+    id: 1,
+    title: 'Post 1',
+    text: 'Some text here...',
+    user: {
       id: 1,
-      title: 'Post 1',
-      text: 'Some text here...',
-      user: {
-        id: 1,
-        firstName: 'Joe',
-        lastName: 'Doe'
-      }
-    },
-    {
-      id: 2,
-      title: 'Post 2',
-      text: 'Some text here...',
-      user: {
-        id: 2,
-        firstName: 'John',
-        lastName: 'Doe'
-      }
+      firstName: 'Joe',
+      lastName: 'Doe'
     }
-    /* ... */
-  ]
-  ```
+  },
+  {
+    id: 2,
+    title: 'Post 2',
+    text: 'Some text here...',
+    user: {
+      id: 2,
+      firstName: 'John',
+      lastName: 'Doe'
+    }
+  }
+  /* ... */
+]
+```
 
   </code-block>
 </code-group>
 
 Just for convenience, it's possible to make Static calls. We are going to use this approach from now on:
- 
+
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.get()
-  ```
+```js
+const posts = await Post.get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts
-  ```
+```http request
+GET /posts
+```
 
   </code-block>
   <code-block label="Response">
 
-  ```js
-  [
-    /* ... */
-    {
+```js
+;[
+  /* ... */
+  {
+    id: 1,
+    title: 'Post 1',
+    text: 'Some text here...',
+    user: {
       id: 1,
-      title: 'Post 1',
-      text: 'Some text here...',
-      user: {
-        id: 1,
-        firstName: 'Joe',
-        lastName: 'Doe'
-      }
-    },
-    {
-      id: 2,
-      title: 'Post 2',
-      text: 'Some text here...',
-      user: {
-        id: 2,
-        firstName: 'John',
-        lastName: 'Doe'
-      }
+      firstName: 'Joe',
+      lastName: 'Doe'
     }
-    /* ... */
-  ]
-  ```
+  },
+  {
+    id: 2,
+    title: 'Post 2',
+    text: 'Some text here...',
+    user: {
+      id: 2,
+      firstName: 'John',
+      lastName: 'Doe'
+    }
+  }
+  /* ... */
+]
+```
 
   </code-block>
 </code-group>
@@ -128,7 +128,7 @@ To retrieve a single record from the database, we can use two methods:
 
 See the [API reference](/api/query-builder-methods#first)
 
-Let's start using `first`. This method will internally use `get` to retrieve a list of records 
+Let's start using `first`. This method will internally use `get` to retrieve a list of records
 and then return the first one.
 
 To get the first **Post** of a list:
@@ -136,43 +136,43 @@ To get the first **Post** of a list:
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.first()
-  ```
+```js
+const posts = await Post.first()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts
-  ```
+```http request
+GET /posts
+```
 
   </code-block>
   <code-block label="Response">
 
-  ```js
-  {
+```js
+{
+  id: 1,
+  title: 'Post 1',
+  text: 'Some text here...',
+  user: {
     id: 1,
-    title: 'Post 1',
-    text: 'Some text here...',
-    user: {
-      id: 1,
-      firstName: 'Joe',
-      lastName: 'Doe'
-    }
+    firstName: 'Joe',
+    lastName: 'Doe'
   }
-  ```
+}
+```
 
   </code-block>
 </code-group>
 
 <alert type="info">It's also possible to use `$first` method, which handle and unwrap responses within "data".</alert>
 
-###  Finding a Specific Record
+### Finding a Specific Record
 
 See the [API reference](/api/query-builder-methods#find)
 
-Different from `first`, the `find` method wil request a specific record from the database. 
+Different from `first`, the `find` method wil request a specific record from the database.
 An identifier must be passed as argument.
 
 To find a specific **Post**:
@@ -180,32 +180,32 @@ To find a specific **Post**:
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.find(1)
-  ```
+```js
+const posts = await Post.find(1)
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts/1
-  ```
+```http request
+GET /posts/1
+```
 
   </code-block>
   <code-block label="Response">
 
-  ```js
-  {
+```js
+{
+  id: 1,
+  title: 'Post 1',
+  text: 'Some text here...',
+  user: {
     id: 1,
-    title: 'Post 1',
-    text: 'Some text here...',
-    user: {
-      id: 1,
-      firstName: 'Joe',
-      lastName: 'Doe'
-    }
+    firstName: 'Joe',
+    lastName: 'Doe'
   }
-  ```
+}
+```
 
   </code-block>
 </code-group>
@@ -235,16 +235,16 @@ We can filter our **Posts** to only get results where `status` is `published`:
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.where('status', 'published').get()
-  ```
+```js
+const posts = await Post.where('status', 'published').get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?filter[status]=published
-  ```
+```http request
+GET /posts?filter[status]=published
+```
 
   </code-block>
 </code-group>
@@ -260,18 +260,16 @@ So we can filter our **Posts** to only get results where `status` of `user` is `
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.where([
-    'user', 'status'
-  ], 'active').get()
-  ```
+```js
+const posts = await Post.where(['user', 'status'], 'active').get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?filter[user][status]=active
-  ```
+```http request
+GET /posts?filter[user][status]=active
+```
 
   </code-block>
 </code-group>
@@ -285,21 +283,21 @@ Now is also possible to pass an object.
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.where({
-    status: 'published',
-    user: {
-      status: 'active'
-    }
-  }).get()
-  ```
+```js
+const posts = await Post.where({
+  status: 'published',
+  user: {
+    status: 'active'
+  }
+}).get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?filter[status]=published&filter[user][status]=active
-  ```
+```http request
+GET /posts?filter[status]=published&filter[user][status]=active
+```
 
   </code-block>
 </code-group>
@@ -309,7 +307,7 @@ Now is also possible to pass an object.
 See the [API reference](/api/query-builder-methods#wherein)
 
 The `whereIn` method is similar to `where`, but it accepts multiple values instead of a single one.
-The first argument is the name of the column, 
+The first argument is the name of the column,
 and the second argument is an array of values to evaluate.
 
 We can filter our **Posts** to only get results where `status` is `published` or `archived`:
@@ -317,18 +315,16 @@ We can filter our **Posts** to only get results where `status` is `published` or
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.whereIn('status', [
-    'published', 'archived'
-  ]).get()
-  ```
+```js
+const posts = await Post.whereIn('status', ['published', 'archived']).get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?filter[status]=published,archived
-  ```
+```http request
+GET /posts?filter[status]=published,archived
+```
 
   </code-block>
 </code-group>
@@ -344,18 +340,19 @@ So we can filter our **Posts** to only get results where `status` of `user` is `
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.whereIn(['user', 'status'], [
-    'active', 'inactive'
-  ]).get()
-  ```
+```js
+const posts = await Post.whereIn(
+  ['user', 'status'],
+  ['active', 'inactive']
+).get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?filter[user][status]=active,inactive
-  ```
+```http request
+GET /posts?filter[user][status]=active,inactive
+```
 
   </code-block>
 </code-group>
@@ -369,21 +366,21 @@ Now is also possible to pass an object.
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.where({
-    status: ['published', 'archived'],
-    user: {
-      status: ['active', 'inactive']
-    }
-  }).get()
-  ```
+```js
+const posts = await Post.where({
+  status: ['published', 'archived'],
+  user: {
+    status: ['active', 'inactive']
+  }
+}).get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?filter[status]=published,archived&filter[user][status]=active,inactive
-  ```
+```http request
+GET /posts?filter[status]=published,archived&filter[user][status]=active,inactive
+```
 
   </code-block>
 </code-group>
@@ -395,7 +392,7 @@ See the [API reference](/api/query-builder-methods#orderby)
 We also need to sort our queries, so let's do this now!
 
 The method we want to use now is `orderBy`. The arguments are the names of the properties we want to sort.
-We can pass as many arguments as we want. 
+We can pass as many arguments as we want.
 
 #### Single Sort
 
@@ -404,16 +401,16 @@ We can sort our **Posts** by the `created_at` date:
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.orderBy('-created_at').get()
-  ```
+```js
+const posts = await Post.orderBy('-created_at').get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?sort=-created_at
-  ```
+```http request
+GET /posts?sort=-created_at
+```
 
   </code-block>
 </code-group>
@@ -425,16 +422,16 @@ And we can sort by their `title` too:
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.orderBy('-created_at', 'title').get()
-  ```
+```js
+const posts = await Post.orderBy('-created_at', 'title').get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?sort=-created_at
-  ```
+```http request
+GET /posts?sort=-created_at
+```
 
   </code-block>
 </code-group>
@@ -452,16 +449,16 @@ The first argument of `orderBy` also accepts an array of string.
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.orderBy(['-created_at', 'title']).get()
-  ```
+```js
+const posts = await Post.orderBy(['-created_at', 'title']).get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?sort=-created_at
-  ```
+```http request
+GET /posts?sort=-created_at
+```
 
   </code-block>
 </code-group>
@@ -478,16 +475,16 @@ Let's eager load the relationships `category` and `tags` of our **Post**:
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.include('category', 'tags').get()
-  ```
+```js
+const posts = await Post.include('category', 'tags').get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?include=category,tags
-  ```
+```http request
+GET /posts?include=category,tags
+```
 
   </code-block>
 </code-group>
@@ -501,16 +498,16 @@ The first argument of `include` also accepts an array of string.
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.include(['category', 'tags']).get()
-  ```
+```js
+const posts = await Post.include(['category', 'tags']).get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?include=category,tags
-  ```
+```http request
+GET /posts?include=category,tags
+```
 
   </code-block>
 </code-group>
@@ -527,16 +524,16 @@ Let's append the attribute `likes` and `shares` of our **Post**:
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.append('likes', 'shares').get()
-  ```
+```js
+const posts = await Post.append('likes', 'shares').get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?append=likes,shares
-  ```
+```http request
+GET /posts?append=likes,shares
+```
 
   </code-block>
 </code-group>
@@ -550,16 +547,16 @@ The first argument of `append` also accepts an array of string.
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.append(['likes', 'shares']).get()
-  ```
+```js
+const posts = await Post.append(['likes', 'shares']).get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?append=likes,shares
-  ```
+```http request
+GET /posts?append=likes,shares
+```
 
   </code-block>
 </code-group>
@@ -582,23 +579,23 @@ We can select only the `title` and the `text` fields of our **Post** model:
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.select('title', 'text').get()
-  ```
+```js
+const posts = await Post.select('title', 'text').get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?fields[posts]=title,text
-  ```
+```http request
+GET /posts?fields[posts]=title,text
+```
 
   </code-block>
 </code-group>
 
 ### Fields of Relationships
 
-The argument is an object, which the name of the first key is the `resource` defined in the model class, 
+The argument is an object, which the name of the first key is the `resource` defined in the model class,
 the name of the other keys are the included relationships, and the values are arrays of fields.
 
 We can select only the `name` field of the category we have to eager loaded:
@@ -606,19 +603,21 @@ We can select only the `name` field of the category we have to eager loaded:
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.include('category').select({
+```js
+const posts = await Post.include('category')
+  .select({
     posts: ['title', 'text'],
     category: ['name']
-  }).get()
-  ```
+  })
+  .get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?include=category&fields[posts]=title,text&fields[category]=name
-  ```
+```http request
+GET /posts?include=category&fields[posts]=title,text&fields[category]=name
+```
 
   </code-block>
 </code-group>
@@ -630,7 +629,7 @@ A very important feature is paginating, so let's do it now!
 There are two methods we will be using here:
 
 - `page` - Set the current page.
-- `limit` -  Set the limit of records per page.
+- `limit` - Set the limit of records per page.
 
 Both methods accept a number as an argument.
 
@@ -639,16 +638,16 @@ Let's say we are at page 1, and we want 20 **Posts** per page:
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.page(1).limit(20).get()
-  ```
+```js
+const posts = await Post.page(1).limit(20).get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?page=1&limit=20
-  ```
+```http request
+GET /posts?page=1&limit=20
+```
 
   </code-block>
 </code-group>
@@ -660,31 +659,31 @@ Let's say we are at page 1, and we want 20 **Posts** per page:
 We may need to add a clause based on a condition, and we can do so by using the `when` method.
 The first argument is the flag, and the second argument is the callback with the clause we want.
 
-
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const search = 'foo'
-  const posts = await Post.when(search, (query, value) => query.where('title', value)).get()
-  ```
+```js
+const search = 'foo'
+const posts = await Post.when(search, (query, value) =>
+  query.where('title', value)
+).get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?filter[title]=foo
-  ```
+```http request
+GET /posts?filter[title]=foo
+```
 
   </code-block>
 </code-group>
-
 
 ## Applying Custom Parameters
 
 See the [API reference](/api/query-builder-methods#params)
 
-We may also need to use parameters that are not provided by [vue-api-query](https://github.com/robsontenorio/vue-api-query),
+We may also need to use parameters that are not provided by [vue-api-query](https://github.com/mindedge/vue-api-query),
 and that's when the `params` method comes in to help.
 
 The argument is an object of the parameters to add to the query.
@@ -692,20 +691,20 @@ The argument is an object of the parameters to add to the query.
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.params({
-    doSomething: 'yes',
-    process: false,
-    multiple: ['awesome', 'amazing', 'super']
-  }).get()
-  ```
+```js
+const posts = await Post.params({
+  doSomething: 'yes',
+  process: false,
+  multiple: ['awesome', 'amazing', 'super']
+}).get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts?doSomething=yes&process=false&multiple=awesome,amazing,super
-  ```
+```http request
+GET /posts?doSomething=yes&process=false&multiple=awesome,amazing,super
+```
 
   </code-block>
 </code-group>
@@ -714,7 +713,7 @@ The argument is an object of the parameters to add to the query.
 
 See the [API reference](/api/query-builder-methods#custom)
 
-In some situations we may also need to define a custom resource endpoint for our model directly in the query. We can override 
+In some situations we may also need to define a custom resource endpoint for our model directly in the query. We can override
 the default resource dynamically by calling the `custom` method.
 
 ### Defining a Static Resource
@@ -726,24 +725,24 @@ We can change the **Post** resource to get the latest **Posts**:
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const posts = await Post.custom('posts/latest').get()
-  ```
+```js
+const posts = await Post.custom('posts/latest').get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /posts/latest
-  ```
+```http request
+GET /posts/latest
+```
 
   </code-block>
 </code-group>
 
 ### Defining a Dynamic Resource
 
-But it's also possible to build dynamic resource endpoints with hierarchies, by supplying the arguments 
-in the correct order. It accepts models and strings as arguments. 
+But it's also possible to build dynamic resource endpoints with hierarchies, by supplying the arguments
+in the correct order. It accepts models and strings as arguments.
 If a model is passed, the model's resource will be used, as well as its primary key's value if available.
 
 We can build a resource to get the latest `Posts` that belongs to a **User**:
@@ -751,24 +750,24 @@ We can build a resource to get the latest `Posts` that belongs to a **User**:
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const user = await User.find(1)
-  const posts = await Post.custom(user, post, 'latest').get()
-  ```
+```js
+const user = await User.find(1)
+const posts = await Post.custom(user, post, 'latest').get()
+```
 
   </code-block>
   <code-block label="User Request">
 
-  ```http request
-  GET /users/1
-  ```
+```http request
+GET /users/1
+```
 
   </code-block>
   <code-block label="Posts Request">
 
-  ```http request
-  GET /users/1/posts/latest
-  ```
+```http request
+GET /users/1/posts/latest
+```
 
   </code-block>
 </code-group>
@@ -779,14 +778,18 @@ We can build a resource to get the latest `Posts` that belongs to a **User**:
 
 See the [API reference](/api/query-builder-methods#config)
 
-The `config` method can be used to configure the current request at query builder. We can pass any config available 
-from the HTTP Instance. If we are using [Axios](https://github.com/axios/axios), 
+The `config` method can be used to configure the current request at query builder. We can pass any config available
+from the HTTP Instance. If we are using [Axios](https://github.com/axios/axios),
 we should pass an [AxiosRequestConfig](https://github.com/axios/axios#request-config).
 
 We can add headers, change the method, anything we want:
 
 ```js
-await Post.config({ headers: { /*...*/ } }).get()
+await Post.config({
+  headers: {
+    /*...*/
+  }
+}).get()
 ```
 
 ## Needless Parent Request
@@ -795,44 +798,44 @@ One thing to note is that in some cases we may not need to make a request to par
 If we already know the model's ID, we just need to initialize the model instance with the ID, instead of use `find`.
 
 We can get a list of **Posts** that belongs to an **User**:
- 
+
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const user = new User({ id: 1 })
-  const posts = user.posts().get()
-  ```
+```js
+const user = new User({ id: 1 })
+const posts = user.posts().get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /users/1/posts
-  ```
+```http request
+GET /users/1/posts
+```
 
   </code-block>
 </code-group>
 
-And the same thing can be done if we want to define a 
+And the same thing can be done if we want to define a
 [dynamic resource](/building-the-query#defining-a-dynamic-resource).
 
 We can create a new **User** instance with the ID:
- 
+
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const user = new User({ id: 1 })
-  const posts = await Post.custom(user, post, 'latest').get()
-  ```
+```js
+const user = new User({ id: 1 })
+const posts = await Post.custom(user, post, 'latest').get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /users/1/posts/latest
-  ```
+```http request
+GET /users/1/posts/latest
+```
 
   </code-block>
 </code-group>
@@ -841,42 +844,41 @@ We can create a new **User** instance with the ID:
 
 Let's mix everything we have learned so far!
 
-We can get a list of latest **Posts**, where `status` is `published`, include the `category` 
-relation, append `likes` attribute, select `title` and `text` fields, order by `created_at`, 
+We can get a list of latest **Posts**, where `status` is `published`, include the `category`
+relation, append `likes` attribute, select `title` and `text` fields, order by `created_at`,
 paginate and custom parameters:
 
 <code-group>
   <code-block label="Query" active>
 
-  ```js
-  const user = new User({ id: 1 })
-  const posts = await Post
-    .where('status', 'published')
-    .include('category')
-    .append('likes')
-    .select('title', 'text')
-    .orderBy('-created_at')
-    .page(1)
-    .limit(20)
-    .params({ process: false })
-    .custom(user, post, 'latest')
-    .get()
-  ```
+```js
+const user = new User({ id: 1 })
+const posts = await Post.where('status', 'published')
+  .include('category')
+  .append('likes')
+  .select('title', 'text')
+  .orderBy('-created_at')
+  .page(1)
+  .limit(20)
+  .params({ process: false })
+  .custom(user, post, 'latest')
+  .get()
+```
 
   </code-block>
   <code-block label="Request">
 
-  ```http request
-  GET /users/1/posts/latest
-  ?filter[status]=published
-  &include=category
-  &append=likes
-  &fields[posts]=title,text
-  &sort=-created_at
-  &page=1
-  &limit=20
-  &process=false
-  ```
+```http request
+GET /users/1/posts/latest
+?filter[status]=published
+&include=category
+&append=likes
+&fields[posts]=title,text
+&sort=-created_at
+&page=1
+&limit=20
+&process=false
+```
 
   </code-block>
 </code-group>

--- a/docs/content/en/configuration.md
+++ b/docs/content/en/configuration.md
@@ -11,7 +11,7 @@ See the [API reference](/api/model-options) for a list of available options.
 
 The first step is to create a base model to define the default options, in order to abstract configuration
 from your models. It should extend the
-[Base Model](https://github.com/robsontenorio/vue-api-query/blob/master/src/Model.js) of [vue-api-query](https://github.com/robsontenorio/vue-api-query).
+[Base Model](https://github.com/mindedge/vue-api-query/blob/master/src/Model.js) of [vue-api-query](https://github.com/mindedge/vue-api-query).
 
 The base model must implement two methods:
 

--- a/docs/content/settings.json
+++ b/docs/content/settings.json
@@ -1,5 +1,5 @@
 {
   "title": "Vue API Query",
-  "url": "https://robsontenorio.github.io/vue-api-query",
-  "github": "robsontenorio/vue-api-query"
+  "url": "https://mindedge.github.io/vue-api-query",
+  "github": "mindedge/vue-api-query"
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ export interface HTTPResponse<T> {
 export type HTTPPromise<T = any> = Promise<HTTPResponse<T>>
 
 export interface WrappedResponse<T> {
-  data: T,
+  data: T
   [key: string]: any
 }
 
@@ -48,7 +48,7 @@ declare class StaticModel {
   /**
    * Create an instance of itself.
    */
-  static instance<M extends typeof Model> (this: M): InstanceType<M>
+  static instance<M extends typeof Model>(this: M): InstanceType<M>
 
   /**
    * Query
@@ -57,96 +57,126 @@ declare class StaticModel {
   /**
    * Configuration of HTTP Instance.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#config|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#configuring-the-request|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#config|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#configuring-the-request|Building the Query}
    */
-  static config<M extends typeof Model> (this: M, config: HTTPRequestConfig): InstanceType<M>
+  static config<M extends typeof Model>(
+    this: M,
+    config: HTTPRequestConfig
+  ): InstanceType<M>
 
   /**
    * Eager load relationships.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
    */
-  static include<M extends typeof Model> (this: M, ...relationships: string[]): InstanceType<M>
+  static include<M extends typeof Model>(
+    this: M,
+    ...relationships: string[]
+  ): InstanceType<M>
 
   /**
    * Eager load relationships.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
    */
-  static include<M extends typeof Model> (this: M, relationships: string[]): InstanceType<M>
+  static include<M extends typeof Model>(
+    this: M,
+    relationships: string[]
+  ): InstanceType<M>
 
   /**
    * Eager load relationships.
    *
    * Alias for the [include()]{@link include} method.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
    */
-  static with<M extends typeof Model> (this: M, ...relationships: string[]): InstanceType<M>
+  static with<M extends typeof Model>(
+    this: M,
+    ...relationships: string[]
+  ): InstanceType<M>
 
   /**
    * Eager load relationships.
    *
    * Alias for the [include()]{@link include} method.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
    */
-  static with<M extends typeof Model> (this: M, relationships: string[]): InstanceType<M>
+  static with<M extends typeof Model>(
+    this: M,
+    relationships: string[]
+  ): InstanceType<M>
 
   /**
    * Append attributes.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#append|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#appending-attributes|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#append|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#appending-attributes|Building the Query}
    */
-  static append<M extends typeof Model> (this: M, ...attributes: string[]): InstanceType<M>
+  static append<M extends typeof Model>(
+    this: M,
+    ...attributes: string[]
+  ): InstanceType<M>
 
   /**
    * Append attributes.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#append|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#appending-attributes|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#append|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#appending-attributes|Building the Query}
    */
-  static append<M extends typeof Model> (this: M, attributes: string[]): InstanceType<M>
+  static append<M extends typeof Model>(
+    this: M,
+    attributes: string[]
+  ): InstanceType<M>
 
   /**
    * Set the columns to be selected.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
    */
-  static select<M extends typeof Model> (this: M, ...columns: string[]): InstanceType<M>
+  static select<M extends typeof Model>(
+    this: M,
+    ...columns: string[]
+  ): InstanceType<M>
 
   /**
    * Set the columns to be selected.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
    */
-  static select<M extends typeof Model> (this: M, columns: string[]): InstanceType<M>
+  static select<M extends typeof Model>(
+    this: M,
+    columns: string[]
+  ): InstanceType<M>
 
   /**
    * Set the columns to be selected.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
    */
-  static select<M extends typeof Model> (this: M, columns: {
-    [related: string]: string[]
-  }): InstanceType<M>
+  static select<M extends typeof Model>(
+    this: M,
+    columns: {
+      [related: string]: string[]
+    }
+  ): InstanceType<M>
 
   /**
    * Add a basic where clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#where|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#evaluating-a-single-value|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#where|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#evaluating-a-single-value|Building the Query}
    */
-  static where<M extends typeof Model> (
+  static where<M extends typeof Model>(
     this: M,
     field: string | string[],
     value: string | number | boolean
@@ -155,10 +185,10 @@ declare class StaticModel {
   /**
    * Add a basic where clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#where|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#evaluating-a-single-value|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#where|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#evaluating-a-single-value|Building the Query}
    */
-  static where<M extends typeof Model> (
+  static where<M extends typeof Model>(
     this: M,
     filter: Record<string, any>
   ): InstanceType<M>
@@ -166,10 +196,10 @@ declare class StaticModel {
   /**
    * Add a "where in" clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#wherein|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#evaluating-multiple-values|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#wherein|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#evaluating-multiple-values|Building the Query}
    */
-  static whereIn<M extends typeof Model> (
+  static whereIn<M extends typeof Model>(
     this: M,
     field: string | string[],
     values: (string | number | boolean)[]
@@ -178,10 +208,10 @@ declare class StaticModel {
   /**
    * Add a "where in" clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#wherein|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#evaluating-multiple-values|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#wherein|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#evaluating-multiple-values|Building the Query}
    */
-  static whereIn<M extends typeof Model> (
+  static whereIn<M extends typeof Model>(
     this: M,
     filter: Record<string, any>
   ): InstanceType<M>
@@ -189,58 +219,74 @@ declare class StaticModel {
   /**
    * Add an "order by" clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#orderby|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#sorting|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#orderby|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#sorting|Building the Query}
    */
-  static orderBy<M extends typeof Model> (this: M, ...columns: string[]): InstanceType<M>
+  static orderBy<M extends typeof Model>(
+    this: M,
+    ...columns: string[]
+  ): InstanceType<M>
 
   /**
    * Add an "order by" clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#orderby|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#sorting|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#orderby|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#sorting|Building the Query}
    */
-  static orderBy<M extends typeof Model> (this: M, columns: string[]): InstanceType<M>
+  static orderBy<M extends typeof Model>(
+    this: M,
+    columns: string[]
+  ): InstanceType<M>
 
   /**
    * Set the current page.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#page|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#paginating|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#page|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#paginating|Building the Query}
    */
-  static page<M extends typeof Model> (this: M, number: number): InstanceType<M>
+  static page<M extends typeof Model>(this: M, number: number): InstanceType<M>
 
   /**
    * Set the page limit.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#limit|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#paginating|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#limit|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#paginating|Building the Query}
    */
-  static limit<M extends typeof Model> (this: M, number: number): InstanceType<M>
+  static limit<M extends typeof Model>(this: M, number: number): InstanceType<M>
 
   /**
    * Add custom parameters to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#params|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#applying-custom-parameters|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#params|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#applying-custom-parameters|Building the Query}
    */
-  static params<M extends typeof Model> (this: M, payload: Record<string, string | number | boolean>): InstanceType<M>
+  static params<M extends typeof Model>(
+    this: M,
+    payload: Record<string, string | number | boolean>
+  ): InstanceType<M>
 
   /**
    * Add a conditional clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#when|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#conditional|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#when|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#conditional|Building the Query}
    */
-  static when<M extends typeof Model, T = any> (this: M, value: T, callback: (query: Builder, value: T) => any): InstanceType<M>
+  static when<M extends typeof Model, T = any>(
+    this: M,
+    value: T,
+    callback: (query: Builder, value: T) => any
+  ): InstanceType<M>
 
   /**
    * Build custom endpoints.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#custom|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#calling-a-custom-resource|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#custom|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#calling-a-custom-resource|Building the Query}
    */
-  static custom<M extends typeof Model> (this: M, ...endpoint: (Model | string)[]): InstanceType<M>
+  static custom<M extends typeof Model>(
+    this: M,
+    ...endpoint: (Model | string)[]
+  ): InstanceType<M>
 
   /**
    * Results
@@ -249,82 +295,88 @@ declare class StaticModel {
   /**
    * Execute the query and get the first result.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#first|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#getting-the-first-record|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#first|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#getting-the-first-record|Building the Query}
    */
-  static first<M extends typeof Model> (this: M): QueryPromise<InstanceType<M>>
+  static first<M extends typeof Model>(this: M): QueryPromise<InstanceType<M>>
 
   /**
    * Execute the query and get the first result.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#first-1|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#getting-the-first-record|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#first-1|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#getting-the-first-record|Building the Query}
    */
-  static $first<M extends typeof Model> (this: M): Promise<InstanceType<M>>
+  static $first<M extends typeof Model>(this: M): Promise<InstanceType<M>>
 
   /**
    * Find a model by its primary key.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#find|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#finding-a-specific-record|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#find|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#finding-a-specific-record|Building the Query}
    */
-  static find<M extends typeof Model> (this: M, id: number | string): QueryPromise<InstanceType<M>>
+  static find<M extends typeof Model>(
+    this: M,
+    id: number | string
+  ): QueryPromise<InstanceType<M>>
 
   /**
    * Find a model by its primary key.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#find-1|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#finding-a-specific-record|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#find-1|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#finding-a-specific-record|Building the Query}
    */
-  static $find<M extends typeof Model> (this: M, id: number | string): Promise<InstanceType<M>>
+  static $find<M extends typeof Model>(
+    this: M,
+    id: number | string
+  ): Promise<InstanceType<M>>
 
   /**
    * Execute the query and get all results.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#get|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#get|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
    */
-  static get<M extends typeof Model> (this: M): QueryPromise<InstanceType<M>[]>
+  static get<M extends typeof Model>(this: M): QueryPromise<InstanceType<M>[]>
 
   /**
    * Execute the query and get all results.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#get-1|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#get-1|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
    */
-  static $get<M extends typeof Model> (this: M): Promise<InstanceType<M>[]>
+  static $get<M extends typeof Model>(this: M): Promise<InstanceType<M>[]>
 
   /**
    * Execute the query and get all results.
    *
    * Alias for the [get()]{@link get} method.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#get|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#get|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
    */
-  static all<M extends typeof Model> (this: M): QueryPromise<InstanceType<M>[]>
+  static all<M extends typeof Model>(this: M): QueryPromise<InstanceType<M>[]>
 
   /**
    * Execute the query and get all results.
    *
    * Alias for the [$get()]{@link $get} method.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#get-1|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#get-1|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
    */
-  static $all<M extends typeof Model> (this: M): Promise<InstanceType<M>[]>
+  static $all<M extends typeof Model>(this: M): Promise<InstanceType<M>[]>
 }
 
 export class Model extends StaticModel {
   /**
    * Instance of the HTTP client which is used to make requests.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/model-options#http|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/installation|Installation}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/model-options#http|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/installation|Installation}
    */
   static $http: any
 
-  constructor (...args: any[])
+  constructor(...args: any[])
 
   /**
    * Settings
@@ -333,85 +385,85 @@ export class Model extends StaticModel {
   /**
    * Instance of the HTTP client which is used to make requests.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/model-options#http|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/installation|Installation}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/model-options#http|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/installation|Installation}
    */
-  get $http (): any
+  get $http(): any
 
   /**
    * This method can be overridden in the model to configure
    * [object-to-formdata]{@link https://github.com/therealparmesh/object-to-formdata#usage|object-to-formdata}.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/model-options#http|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/model-options#http|API Reference}
    * @see {@link https://github.com/therealparmesh/object-to-formdata#usage|object-to-formdata}
    */
-  formData (): {
-    indices: boolean,
-    nullsAsUndefineds: boolean,
-    booleansAsIntegers: boolean,
-    allowEmptyArrays: boolean,
+  formData(): {
+    indices: boolean
+    nullsAsUndefineds: boolean
+    booleansAsIntegers: boolean
+    allowEmptyArrays: boolean
   }
 
   /**
    * Resource route of the model which is used to build the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/model-options#resource|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/configuration#creating-the-domain-models|Configuration}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/model-options#resource|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/configuration#creating-the-domain-models|Configuration}
    */
-  resource (): string
+  resource(): string
 
   /**
    * Primary key of the model which is used to build the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/model-options#primarykey|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/configuration#changing-the-primary-key|Configuration}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/model-options#primarykey|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/configuration#changing-the-primary-key|Configuration}
    */
-  primaryKey (): string
+  primaryKey(): string
 
   /**
    * The "data" wrapper that should be checked when retrieving models
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/model-options#wrap|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/configuration#changing-the-wrapper|Configuration}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/model-options#wrap|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/configuration#changing-the-wrapper|Configuration}
    */
-  wrap (): string
+  wrap(): string
 
   /**
    * This method can be used to lazy load relationships of a model and apply model instances to them.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/model-options#hasmany|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/configuration#lazy-loading-relationships|Configuration}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/model-options#hasmany|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/configuration#lazy-loading-relationships|Configuration}
    */
-  hasMany<T extends typeof Model> (model: T): InstanceType<T>
+  hasMany<T extends typeof Model>(model: T): InstanceType<T>
 
   /**
    * This method can be implemented in the model to apply model instances to eager loaded relationships.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/model-options#relations|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/configuration#eager-loaded-relationships|Configuration}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/model-options#relations|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/configuration#eager-loaded-relationships|Configuration}
    */
-  relations (): Record<string, typeof Model>
+  relations(): Record<string, typeof Model>
 
   /**
    * Base URL which is used and prepended to make requests.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/model-options#baseurl|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/configuration#creating-a-base-model|Configuration}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/model-options#baseurl|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/configuration#creating-a-base-model|Configuration}
    */
-  baseURL (): string
+  baseURL(): string
 
   /**
    * Request method which is used to make requests.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/model-options#request|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/configuration#creating-a-base-model|Configuration}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/model-options#request|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/configuration#creating-a-base-model|Configuration}
    */
-  request (config: HTTPRequestConfig): HTTPPromise
+  request(config: HTTPRequestConfig): HTTPPromise
 
   /**
    * From resource.
    */
-  private _from (url: string): void
+  private _from(url: string): void
 
   /**
    * Helpers
@@ -420,43 +472,43 @@ export class Model extends StaticModel {
   /**
    * Get the primary key of the model.
    */
-  private getPrimaryKey (): string | number
+  private getPrimaryKey(): string | number
 
   /**
    * Determines whether the model has an ID.
    */
-  private hasId (): boolean
+  private hasId(): boolean
 
   /**
    * Determines whether the ID is valid.
    */
-  private isValidId (id: string | number): boolean
+  private isValidId(id: string | number): boolean
 
   /**
    * The model's endpoint.
    */
-  private endpoint (): string
+  private endpoint(): string
 
   /**
    * This method can be overridden in the model to customize the name of the query parameters.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/model-options#parameternames|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/configuration#customizing-query-parameters|Configuration}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/model-options#parameternames|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/configuration#customizing-query-parameters|Configuration}
    */
-  protected parameterNames (): {
-    include: string,
-    filter: string,
-    sort: string,
-    fields: string,
-    append: string,
-    page: string,
+  protected parameterNames(): {
+    include: string
+    filter: string
+    sort: string
+    fields: string
+    append: string
+    page: string
     limit: string
   }
 
   /**
    * This method can be overridden in the model to configure `qs`.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/model-options#stringifyOptions|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/model-options#stringifyOptions|API Reference}
    * @see {@link https://github.com/ljharb/qs#stringifying|qs}
    */
   protected stringifyOptions(): IStringifyOptions
@@ -468,176 +520,174 @@ export class Model extends StaticModel {
   /**
    * Configuration of HTTP Instance.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#config|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#configuring-the-request|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#config|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#configuring-the-request|Building the Query}
    */
-  config (config: HTTPRequestConfig): this
+  config(config: HTTPRequestConfig): this
 
   /**
    * Eager load relationships.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
    */
-  include (...relationships: string[]): this
+  include(...relationships: string[]): this
 
   /**
    * Eager load relationships.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
    */
-  include (relationships: string[]): this
-
-  /**
-   * Eager load relationships.
-   *
-   * Alias for the [include()]{@link include} method.
-   *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
-   */
-  with (...relationships: string[]): this
+  include(relationships: string[]): this
 
   /**
    * Eager load relationships.
    *
    * Alias for the [include()]{@link include} method.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
    */
-  with (relationships: string[]): this
+  with(...relationships: string[]): this
+
+  /**
+   * Eager load relationships.
+   *
+   * Alias for the [include()]{@link include} method.
+   *
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
+   */
+  with(relationships: string[]): this
 
   /**
    * Append attributes.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#append|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#appending-attributes|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#append|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#appending-attributes|Building the Query}
    */
-  append (...attributes: string[]): this
+  append(...attributes: string[]): this
 
   /**
    * Append attributes.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#append|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#appending-attributes|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#append|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#appending-attributes|Building the Query}
    */
-  append (attributes: string[]): this
+  append(attributes: string[]): this
 
   /**
    * Set the columns to be selected.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
    */
-  select (...columns: string[]): this
+  select(...columns: string[]): this
 
   /**
    * Set the columns to be selected.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
    */
-  select (columns: string[]): this
+  select(columns: string[]): this
 
   /**
    * Set the columns to be selected.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
    */
-  select (columns: {
-    [related: string]: string[]
-  }): this
+  select(columns: { [related: string]: string[] }): this
 
   /**
    * Add a basic where clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#where|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#evaluating-a-single-value|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#where|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#evaluating-a-single-value|Building the Query}
    */
-  where (field: string | string[], value: string | number | boolean): this
+  where(field: string | string[], value: string | number | boolean): this
 
   /**
    * Add a basic where clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#where|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#evaluating-a-single-value|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#where|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#evaluating-a-single-value|Building the Query}
    */
-  where (filter: Record<string, any>): this
+  where(filter: Record<string, any>): this
 
   /**
    * Add a "where in" clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#wherein|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#evaluating-multiple-values|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#wherein|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#evaluating-multiple-values|Building the Query}
    */
-  whereIn (field: string | string[], array: (string | number | boolean)[]): this
+  whereIn(field: string | string[], array: (string | number | boolean)[]): this
 
   /**
    * Add a "where in" clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#wherein|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#evaluating-multiple-values|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#wherein|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#evaluating-multiple-values|Building the Query}
    */
-  whereIn (filter: Record<string, any>): this
+  whereIn(filter: Record<string, any>): this
 
   /**
    * Add an "order by" clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#orderby|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#sorting|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#orderby|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#sorting|Building the Query}
    */
-  orderBy (...columns: string[]): this
+  orderBy(...columns: string[]): this
 
   /**
    * Add an "order by" clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#orderby|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#sorting|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#orderby|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#sorting|Building the Query}
    */
-  orderBy (columns: string[]): this
+  orderBy(columns: string[]): this
 
   /**
    * Set the current page.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#page|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#paginating|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#page|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#paginating|Building the Query}
    */
-  page (number: number): this
+  page(number: number): this
 
   /**
    * Set the page limit.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#limit|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#paginating|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#limit|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#paginating|Building the Query}
    */
-  limit (number: number): this
+  limit(number: number): this
 
   /**
    * Add custom parameters to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#params|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#applying-custom-parameters|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#params|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#applying-custom-parameters|Building the Query}
    */
-  params (payload: Record<string, string | number | boolean>): this
+  params(payload: Record<string, string | number | boolean>): this
 
   /**
    * Add a conditional clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#when|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#conditional|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#when|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#conditional|Building the Query}
    */
   when<T = any>(value: T, callback: (query: Builder, value: T) => any): this
 
   /**
    * Build custom endpoints.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#custom|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#calling-a-custom-resource|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#custom|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#calling-a-custom-resource|Building the Query}
    */
-  custom (...endpoint: (Model | string)[]): this
+  custom(...endpoint: (Model | string)[]): this
 
   /**
    * Results
@@ -646,70 +696,70 @@ export class Model extends StaticModel {
   /**
    * Execute the query and get the first result.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#first|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#getting-the-first-record|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#first|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#getting-the-first-record|Building the Query}
    */
-  first (): QueryPromise<this>
+  first(): QueryPromise<this>
 
   /**
    * Execute the query and get the first result.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#first-1|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#getting-the-first-record|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#first-1|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#getting-the-first-record|Building the Query}
    */
-  $first (): Promise<this>
+  $first(): Promise<this>
 
   /**
    * Find a model by its primary key.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#find|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#finding-a-specific-record|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#find|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#finding-a-specific-record|Building the Query}
    */
-  find (identifier: number | string): QueryPromise<this>
+  find(identifier: number | string): QueryPromise<this>
 
   /**
    * Find a model by its primary key.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#find-1|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#finding-a-specific-record|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#find-1|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#finding-a-specific-record|Building the Query}
    */
-  $find (identifier: number | string): Promise<this>
+  $find(identifier: number | string): Promise<this>
 
   /**
    * Execute the query and get all results.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#get|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#get|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
    */
-  get (): QueryPromise<this[]>
+  get(): QueryPromise<this[]>
 
   /**
    * Execute the query and get all results.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#get-1|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#get-1|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
    */
-  $get (): Promise<this[]>
+  $get(): Promise<this[]>
 
   /**
    * Execute the query and get all results.
    *
    * Alias for the [get()]{@link get} method.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#get|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#get|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
    */
-  all (): QueryPromise<this[]>
+  all(): QueryPromise<this[]>
 
   /**
    * Execute the query and get all results.
    *
    * Alias for the [$get()]{@link $get} method.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#get-1|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#get-1|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
    */
-  $all (): Promise<this[]>
+  $all(): Promise<this[]>
 
   /**
    * Common CRUD operations
@@ -718,36 +768,36 @@ export class Model extends StaticModel {
   /**
    * Delete the model from the database.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/crud-operations#delete|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/performing-operations#deleting-a-model|Performing Operations}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/crud-operations#delete|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/performing-operations#deleting-a-model|Performing Operations}
    */
-  delete (): Promise<any>
+  delete(): Promise<any>
 
   /**
    * Save or update a model in the database, then return the instance.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/crud-operations#save|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/performing-operations#saving-a-model|Performing Operations}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/crud-operations#save|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/performing-operations#saving-a-model|Performing Operations}
    */
-  save (): Promise<this>
+  save(): Promise<this>
 
   /**
    * Save a model in the database, then return the instance.
    */
-  private _create (): Promise<this>
+  private _create(): Promise<this>
 
   /**
    * Update a model in the database, then return the instance.
    */
-  private _update (): Promise<this>
+  private _update(): Promise<this>
 
   /**
    * Make a `PATCH` request to update a model in the database, then return the instance.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/crud-operations#patch|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/performing-operations#saving-a-model|Performing Operations}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/crud-operations#patch|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/performing-operations#saving-a-model|Performing Operations}
    */
-  patch (): Promise<this>
+  patch(): Promise<this>
 
   /**
    * Relationship operations
@@ -756,26 +806,26 @@ export class Model extends StaticModel {
   /**
    * Create a new related model.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/relationship-operations#for|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/performing-operations#creating-related-models|Performing Operations}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/relationship-operations#for|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/performing-operations#creating-related-models|Performing Operations}
    */
-  for (...models: Model[]): this
+  for(...models: Model[]): this
 
   /**
    * Create a new related model.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/relationship-operations#attach|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/performing-operations#attaching-a-model|Performing Operations}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/relationship-operations#attach|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/performing-operations#attaching-a-model|Performing Operations}
    */
-  attach (params: Record<string, any>): Promise<any>
+  attach(params: Record<string, any>): Promise<any>
 
   /**
    * Update a related model.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/relationship-operations#sync|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/performing-operations#syncing-a-model|Performing Operations}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/relationship-operations#sync|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/performing-operations#syncing-a-model|Performing Operations}
    */
-  sync (params: Record<string, any>): Promise<any>
+  sync(params: Record<string, any>): Promise<any>
 }
 
 declare class Builder {
@@ -786,158 +836,156 @@ declare class Builder {
   /**
    * Eager load relationships.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
    */
-  include (...relationships: string[]): this
+  include(...relationships: string[]): this
 
   /**
    * Eager load relationships.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
    */
-  include (relationships: string[]): this
-
-  /**
-   * Eager load relationships.
-   *
-   * Alias for the [include()]{@link include} method.
-   *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
-   */
-  with (...relationships: string[]): this
+  include(relationships: string[]): this
 
   /**
    * Eager load relationships.
    *
    * Alias for the [include()]{@link include} method.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
    */
-  with (relationships: string[]): this
+  with(...relationships: string[]): this
+
+  /**
+   * Eager load relationships.
+   *
+   * Alias for the [include()]{@link include} method.
+   *
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#include|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#including-relationships|Building the Query}
+   */
+  with(relationships: string[]): this
 
   /**
    * Append attributes.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#append|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#appending-attributes|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#append|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#appending-attributes|Building the Query}
    */
-  append (...attributes: string[]): this
+  append(...attributes: string[]): this
 
   /**
    * Append attributes.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#append|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#appending-attributes|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#append|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#appending-attributes|Building the Query}
    */
-  append (attributes: string[]): this
+  append(attributes: string[]): this
 
   /**
    * Set the columns to be selected.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
    */
-  select (...columns: string[]): this
+  select(...columns: string[]): this
 
   /**
    * Set the columns to be selected.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
    */
-  select (columns: string[]): this
+  select(columns: string[]): this
 
   /**
    * Set the columns to be selected.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#select|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#selecting-fields|Building the Query}
    */
-  select (columns: {
-    [related: string]: string[]
-  }): this
+  select(columns: { [related: string]: string[] }): this
 
   /**
    * Add a basic where clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#where|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#evaluating-a-single-value|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#where|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#evaluating-a-single-value|Building the Query}
    */
-  where (field: string | string[], value: string | number | boolean): this
+  where(field: string | string[], value: string | number | boolean): this
 
   /**
    * Add a basic where clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#where|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#evaluating-a-single-value|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#where|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#evaluating-a-single-value|Building the Query}
    */
-  where (filter: Record<string, any>): this
+  where(filter: Record<string, any>): this
 
   /**
    * Add a "where in" clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#wherein|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#evaluating-multiple-values|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#wherein|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#evaluating-multiple-values|Building the Query}
    */
-  whereIn (field: string | string[], array: (string | number | boolean)[]): this
+  whereIn(field: string | string[], array: (string | number | boolean)[]): this
 
   /**
    * Add a "where in" clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#wherein|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#evaluating-multiple-values|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#wherein|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#evaluating-multiple-values|Building the Query}
    */
-  whereIn (filter: Record<string, any>): this
+  whereIn(filter: Record<string, any>): this
 
   /**
    * Add an "order by" clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#orderby|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#sorting|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#orderby|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#sorting|Building the Query}
    */
-  orderBy (...columns: string[]): this
+  orderBy(...columns: string[]): this
 
   /**
    * Add an "order by" clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#orderby|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#sorting|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#orderby|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#sorting|Building the Query}
    */
-  orderBy (columns: string[]): this
+  orderBy(columns: string[]): this
 
   /**
    * Set the current page.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#page|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#paginating|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#page|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#paginating|Building the Query}
    */
-  page (number: number): this
+  page(number: number): this
 
   /**
    * Set the page limit.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#limit|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#paginating|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#limit|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#paginating|Building the Query}
    */
-  limit (number: number): this
+  limit(number: number): this
 
   /**
    * Add custom parameters to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#params|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#applying-custom-parameters|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#params|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#applying-custom-parameters|Building the Query}
    */
-  params (payload: Record<string, string | number | boolean>): this
+  params(payload: Record<string, string | number | boolean>): this
 
   /**
    * Add a conditional clause to the query.
    *
-   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#when|API Reference}
-   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#conditional|Building the Query}
+   * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#when|API Reference}
+   * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#conditional|Building the Query}
    */
   when<T = any>(value: T, callback: (query: this, value: T) => any): this
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/robsontenorio/vue-api-query.git"
+    "url": "git+https://github.com/mindedge/vue-api-query.git"
   },
   "keywords": [
     "vue",
@@ -42,9 +42,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/robsontenorio/vue-api-query/issues"
+    "url": "https://github.com/mindedge/vue-api-query/issues"
   },
-  "homepage": "https://github.com/robsontenorio/vue-api-query#readme",
+  "homepage": "https://github.com/mindedge/vue-api-query#readme",
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
## Checklist

- [x] Tests
- [x] Docs
- [x] Type definitions 

**Changes:**
- Added wrap and _unwrap methods to Model.js to mimic Laravel's resource data wrapping. This makes for `$first`, `$find`, `$get`, and `$all` obsolete but I kept them for backward compatibility. The the overloadable `wrap()` allows you to automatically unwrap using the standard `first`, `find`, `get`, `all` methods but also change what the wrapper key is in case you don't want to use the standard 'data' property
- Lock the defu package to 6.1.2. Version 6.1.3+ has a regression that prevents exported objects from merging with plain objects.
- Added unit tests for the new wrap() method
- Added new `wrap()` type
- Updated documentation for new `wrap()` type

