### PR TITLE
Feat/add file return

### DIFF
--- a/docs/content/en/api/query-builder-methods.md
+++ b/docs/content/en/api/query-builder-methods.md
@@ -363,3 +363,21 @@ await Model.$find(1)
 
 <alert type="info">These `$`-prefixed convenience methods always return the requested content.
 They handle and unwrap responses within "data".</alert>
+
+## `file`
+- Returns: `Binary`
+
+Execute the query with $http.responseType as `blob` and returns a binary
+
+```js
+// get the blob
+const data = await Model.file()
+
+// force file download
+const url = window.URL.createObjectURL(new Blob([data]));
+const link = document.createElement('a');
+link.href = url;
+link.setAttribute('download', 'model.xlsx'); //or any other extension
+document.body.appendChild(link);
+link.click();
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -736,6 +736,14 @@ export class Model extends StaticModel {
   /**
    * Execute the query and get all results.
    *
+   * @see {@link https://robsontenorio.github.io/vue-api-query/api/query-builder-methods#file|API Reference}
+   * @see {@link https://robsontenorio.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
+   */
+  file(): QueryPromise<BlobPart[]>
+
+  /**
+   * Execute the query and get all results.
+   *
    * @see {@link https://mindedge.github.io/vue-api-query/api/query-builder-methods#get-1|API Reference}
    * @see {@link https://mindedge.github.io/vue-api-query/building-the-query#retrieving-a-list-of-records|Building the Query}
    */

--- a/src/Model.js
+++ b/src/Model.js
@@ -469,6 +469,28 @@ export default class Model extends StaticModel {
     })
   }
 
+  file() {
+    let base = this._fromResource || `${this.baseURL()}/${this.resource()}`
+    base = this._customResource
+      ? `${this.baseURL()}/${this._customResource}`
+      : base
+
+    let url = `${base}${this._builder.query()}`
+
+    return this.request(
+      this._reqConfig({
+        url,
+        method: 'GET',
+        responseType: 'blob',
+        headers: {
+          accept: 'application/octet-stream'
+        }
+      })
+    ).then((response) => {
+      return response.data
+    })
+  }
+
   $get() {
     return this.get().then((response) => response.data || response)
   }

--- a/src/StaticModel.js
+++ b/src/StaticModel.js
@@ -146,6 +146,12 @@ export default class StaticModel {
     return self.get()
   }
 
+  static file() {
+    let self = this.instance()
+
+    self.file()
+  }
+
   static all() {
     let self = this.instance()
 


### PR DESCRIPTION
## Checklist

- [x] Tests
- [x] Docs
- [x] Type definitions 

the .file() method execute a get() but returning a BlobPart[] instead of Collection to be used with file exports like Excels.

Brought in from https://github.com/BVI106/vue-api-query/tree/dev in reference to the below PR:
 and https://github.com/robsontenorio/vue-api-query/pull/266